### PR TITLE
Add option to use dashes instead of spaces

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -61,6 +61,10 @@ OPTIONS AND ARGUMENTS
               Specify the path to a dictionary file.
 
 
+       -n, --no-spaces
+              Separate words with spaces instead of dashes.
+
+
        The default word count in the passphrase is 6.  To change this, specify
        a number as the word-count positional  argument  after  the  pass-name.
        You  can  specify  the word count as low as 1, although this is clearly

--- a/genphrase-resources/_phrase.py
+++ b/genphrase-resources/_phrase.py
@@ -21,6 +21,7 @@ def posint(thing):
 def main():
     """Entry point."""
     words = []
+    separator = "-" if ARGS_NS.no_spaces else " "
     with open(ARGS_NS.dict, "r") as dfile:
         # Diceware dictionary may not have a fixed format spec, but a) line
         # begins with numeral 1-6, b) there should be seperator(s) between
@@ -36,7 +37,7 @@ def main():
         sys.exit(1)
     rand_indices = [RNG.randint(0, len(words) - 1) for _ in
                     xrange(ARGS_NS.count)]
-    passphrase = " ".join((words[i] for i in rand_indices))
+    passphrase = separator.join((words[i] for i in rand_indices))
     sys.stdout.write("%s\n" % passphrase)
 
 
@@ -45,6 +46,8 @@ NUMS = frozenset("123456")
 OPT_PARSER = ArgumentParser(description="Generate diceware-like passphrase.")
 OPT_PARSER.add_argument("-d", "--dict", metavar="FILE", required=True,
                         help="path to diceware-like dictionary")
+OPT_PARSER.add_argument("-n", "--no-spaces", action="store_true", dest="no_spaces",
+                        help="separate words with spaces instead of dashes")
 OPT_PARSER.add_argument("count", metavar="N", default=DEFAULT_LEN, type=posint,
                         nargs="?",
                         help="word count (default: %d)" % DEFAULT_LEN)

--- a/genphrase.bash
+++ b/genphrase.bash
@@ -49,7 +49,7 @@ GENPHRASE_RESOURCES="$EXTENSIONS/genphrase-resources"
 GENPHRASE_DEFAULT_DICT="$GENPHRASE_RESOURCES/eff_large_wordlist.txt"
 GENPHRASE_EXEC="$GENPHRASE_RESOURCES/_phrase.py"
 GENPHRASE_DEFAULT_WORDCOUNT=6
-CMD_GENPHRASE_USAGE="Usage: $PROGRAM $COMMAND [-h,--help] [-c,--clip] [-f,--force] [-i,--in-place] [-q,--qrcode] [-d <PATH>,--dict=<PATH>] pass-name [word-count]"
+CMD_GENPHRASE_USAGE="Usage: $PROGRAM $COMMAND [-h,--help] [-c,--clip] [-f,--force] [-i,--in-place] [-q,--qrcode] [-n, --no-spaces] [-d <PATH>,--dict=<PATH>] pass-name [word-count]"
 
 
 cmd_genphrase_help () {
@@ -62,7 +62,8 @@ Similar to "$PROGRAM generate", but generate a passphrase of given word count
 
 Options:
     The options follow the interface of "$PROGRAM generate", except that the
-    "-n / --no-symbols" option is not necessary.
+    "-n / --no-symbols" option is replaced with "--no-spaces" option (see
+    below).
 
     -h, --help		Show this help and exit.
     -c, --clip		Write generated passphrase to clipboard, to be erased
@@ -78,13 +79,16 @@ Options:
 
     -d <PATH>, --dict=<PATH>
      			Specify path to dictionary file.
+
+    -n, --no-spaces
+                Separate words with spaces instead of dashes.
 __genphrase_usage_097612_EOF
 }
 
 
 cmd_genphrase_exec () {
-    local opts wanthelp=0 qrcode=0 clip=0 force=0 inplace=0 dict="$GENPHRASE_DEFAULT_DICT" passphrase
-    opts="$($GETOPT -o "hcfiqd:" -l "help,clip,force,in-place,qrcode,dict:" -n "$PROGRAM $COMMAND" -- "$@")"
+    local opts wanthelp=0 qrcode=0 clip=0 force=0 inplace=0 nospaces=0 dict="$GENPHRASE_DEFAULT_DICT" passphrase
+    opts="$($GETOPT -o "hcfiqnd:" -l "help,clip,force,in-place,qrcode,nospaces,dict:" -n "$PROGRAM $COMMAND" -- "$@")"
     local err=$?
     eval set -- "$opts"
     while true; do
@@ -94,6 +98,7 @@ cmd_genphrase_exec () {
 	    -f|--force) force=1; shift ;;
 	    -i|--in-place) inplace=1; shift ;;
 	    -q|--qrcode) qrcode=1; shift ;;
+        -n|--no-spaces) nospaces=1; shift ;;
 	    -d|--dict) dict="$2"; shift 2 ;;
 	    --) shift; break ;;
 	esac
@@ -126,12 +131,23 @@ cmd_genphrase_exec () {
 	yesno "An entry already exists for $path. Overwrite it?"
     fi
 
-    
-    if ! { passphrase="$("$GENPHRASE_EXEC" -d "$dict" "$wcount")" ; } ; then
+    exec_extra_opts=""
+    if [[ $nospaces -eq 1 ]]; then
+        exec_extra_opts="$exec_extra_opts-n"
+    fi
+
+    if ! { passphrase="$("$GENPHRASE_EXEC" "$exec_extra_opts" -d "$dict" "$wcount")" ; } ; then
 	die "Error: passphrase generation failed."
     fi
 
-    if ! [[ "$(echo "$passphrase" | wc -w)" -eq "$wcount" ]]; then
+    # if nospaces is set, translate dashes back to spaces so wc would understand us
+    if [[ $nospaces -eq 0 ]]; then
+        result_wcount="$(echo "$passphrase" | wc -w)";
+    else
+        result_wcount="$(echo "$passphrase" | tr '-' ' ' | wc -w)";
+    fi
+
+    if ! [[ "$result_wcount" -eq "$wcount" ]]; then
 	die "Error: passphrase generation failed (word count mismatch)."
     fi
 

--- a/genphrase.bash
+++ b/genphrase.bash
@@ -131,12 +131,8 @@ cmd_genphrase_exec () {
 	yesno "An entry already exists for $path. Overwrite it?"
     fi
 
-    exec_extra_opts=""
-    if [[ $nospaces -eq 1 ]]; then
-        exec_extra_opts="$exec_extra_opts-n"
-    fi
-
-    if ! { passphrase="$("$GENPHRASE_EXEC" "$exec_extra_opts" -d "$dict" "$wcount")" ; } ; then
+    nospaces_arg=${nospaces/0/} # substitution below would work only if the parameter is null
+    if ! { passphrase="$("$GENPHRASE_EXEC" ${nospaces_arg:+-n} -d "$dict" "$wcount")" ; } ; then
 	die "Error: passphrase generation failed."
     fi
 

--- a/pass-genphrase.1
+++ b/pass-genphrase.1
@@ -75,6 +75,10 @@ In addition, the following option is specific to
 \fB\-d\fR \fIpath\fR, \fB\-\-dict\fR=\fIpath\fR
 Specify the path to a dictionary file.
 
+.TP
+\fB\-n\fR, \fB\-\-no\-spaces\fR
+Separate words with spaces instead of dashes.
+
 .PP
 The default word count in the passphrase is 6.  To change this, specify a
 number as the \fIword-count\fR positional argument after the \fIpass-name\fR.

--- a/tests/runall.sh
+++ b/tests/runall.sh
@@ -109,6 +109,7 @@ fi
 # Run them.
 expect_true "help" "./test_help.sh"
 expect_true "generate default" "./test_default.sh"
+expect_true "generate nospaces" "./test_nospaces.sh"
 expect_true "specify length" "./test_len.sh"
 expect_true "alt. dictionary (Diceware English)" "./test_dict_en.sh"
 expect_true "alt. dictionary (Diceware Czech)" "./test_dict_cz.sh"


### PR DESCRIPTION
Some sites and services do not allow passwords with spaces in them. This introduces option `-n` (`--no-spaces`) which tells the Python helper to separate words with dashes instead.

The option is named similarly to option `-n` (`--no-characters`) seen in `pass generate` and has the same function, that is, to generate a more 'acceptable' sequence.